### PR TITLE
Tighten up the Jenkinsfile for ci.j.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node('docker') {
   /* Make sure our directory is there, if Docker creates it, it gets owned by 'root' */
   sh 'mkdir -p $HOME/.m2'
   
-  docker.image('maven:3.3.9-jdk-7').inside(containerArgs) {
+  docker.image('maven:3.3-jdk-7').inside(containerArgs) {
     timestamps {
       sh 'mvn -B -U -e -Dmaven.test.failure.ignore=true -Duser.home=/var/maven clean install'
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,25 @@
-node {
+#!/usr/bin/env groovy
+
+node('docker') {
+  /* clean out the workspace just to be safe */
+  deleteDir()
+  
+  /* Grab our source for this build */
   checkout scm
-  sh 'mvn clean install'
+  
+  stage 'Build'
+  /* Performing some clever trickery to map our ~/.m2 into the container */
+  String containerArgs = '-v $HOME/.m2:/var/maven/.m2'
+  /* Make sure our directory is there, if Docker creates it, it gets owned by 'root' */
+  sh 'mkdir -p $HOME/.m2'
+  
+  docker.image('maven:3.3.9-jdk-7').inside(containerArgs) {
+    timestamps {
+      sh 'mvn -B -U -e -Dmaven.test.failure.ignore=true -Duser.home=/var/maven clean install'
+    }
+  }
+  
+  stage 'Archive'
+  junit 'target/surefire-reports/**/*.xml'
+  archiveArtifacts artifacts: 'target/**/*.jar', fingerprint: true
 }


### PR DESCRIPTION
At some point I would like to replace this with the [global library work](https://github.com/jenkins-infra/pipeline-global-library) I have been tinkering with in the lab.