### PR TITLE
JENKINS-40207 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -66,6 +67,24 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <version>3.0.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
@@ -1,0 +1,60 @@
+package org.jenkinsci.plugins.displayurlapi;
+
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.tasks.junit.TestResult;
+import hudson.tasks.test.AbstractTestResultAction;
+import hudson.tasks.test.TestObject;
+
+/**
+ * Display URL Provider for the Classical Jenkins UI
+ */
+@Extension
+public class ClassicDisplayURLProvider extends DisplayURLProvider {
+    @Override
+    public String getRunURL(Run<?, ?> run) {
+        return getRoot() + Util.encode(run.getUrl());
+    }
+
+    @Override
+    public String getChangesURL(Run<?, ?> run) {
+        return getJobURL(run.getParent()) + "changes";
+    }
+
+    @Override
+    public String getJobURL(Job<?, ?> job) {
+        return getRoot() + Util.encode(job.getUrl());
+    }
+
+    @Override
+    public String getTestUrl(hudson.tasks.test.TestResult result) {
+        String buildUrl = getRunURL(result.getRun());
+        AbstractTestResultAction action = result.getTestResultAction();
+
+        TestObject parent = result.getParent();
+        TestResult testResultRoot = null;
+        while(parent != null) {
+            if (parent instanceof TestResult) {
+                testResultRoot = (TestResult) parent;
+                break;
+            }
+            parent = parent.getParent();
+        }
+
+        String testUrl = action.getUrlName()
+                + (testResultRoot != null ? testResultRoot.getUrl() : "")
+                + result.getUrl();
+
+        String[] pathComponents = testUrl.split("/");
+        StringBuilder buf = new StringBuilder();
+        for (String c : pathComponents) {
+            buf.append(Util.rawEncode(c)).append('/');
+        }
+        // remove last /
+        buf.deleteCharAt(buf.length() - 1);
+
+        return buildUrl + buf.toString();
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/AbstractDisplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/AbstractDisplayAction.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.displayurlapi.actions;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+import hudson.model.Action;
+import org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public abstract class AbstractDisplayAction implements Action {
+
+    public static final String URL_NAME = "display";
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return URL_NAME;
+    }
+
+    public final Object doRedirect(StaplerRequest req, StaplerResponse rsp) throws IOException {
+        DisplayURLProvider provider = lookupProvider();
+        rsp.sendRedirect(HttpServletResponse.SC_MOVED_TEMPORARILY, getRedirectURL(provider));
+        return null;
+    }
+
+    protected abstract String getRedirectURL(DisplayURLProvider provider);
+
+    DisplayURLProvider lookupProvider() {
+        Iterable<DisplayURLProvider> all = DisplayURLProvider.all();
+        DisplayURLProvider defaultProvider = Iterables.find(all, Predicates.instanceOf(ClassicDisplayURLProvider.class));
+        Iterable<DisplayURLProvider> availableProviders = Iterables.filter(all, Predicates.not(Predicates.instanceOf(ClassicDisplayURLProvider.class)));
+        return Iterables.getFirst(availableProviders, defaultProvider);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/JobDisplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/JobDisplayAction.java
@@ -1,0 +1,38 @@
+package org.jenkinsci.plugins.displayurlapi.actions;
+
+import com.google.common.collect.ImmutableList;
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Job;
+import jenkins.model.TransientActionFactory;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+public class JobDisplayAction extends AbstractDisplayAction {
+
+    private final Job job;
+
+    JobDisplayAction(Job job) {
+        this.job = job;
+    }
+
+    protected String getRedirectURL(DisplayURLProvider provider) {
+        return provider.getJobURL(job);
+    }
+
+    @Extension
+    public static class TransientActionFactoryImpl extends TransientActionFactory {
+        @Override
+        public Class type() {
+            return Job.class;
+        }
+
+        @Nonnull
+        @Override
+        public Collection<? extends Action> createFor(@Nonnull Object target) {
+            return ImmutableList.of(new JobDisplayAction((Job) target));
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/RunDisplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/RunDisplayAction.java
@@ -1,0 +1,61 @@
+package org.jenkinsci.plugins.displayurlapi.actions;
+
+import com.google.common.collect.ImmutableList;
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Run;
+import hudson.tasks.test.AbstractTestResultAction;
+import hudson.tasks.test.TestResult;
+import jenkins.model.TransientActionFactory;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+public class RunDisplayAction extends AbstractDisplayAction {
+    private final Run run;
+
+    RunDisplayAction(Run run) {
+        this.run = run;
+    }
+
+    @Override
+    protected String getRedirectURL(DisplayURLProvider provider) {
+        StaplerRequest req = Stapler.getCurrentRequest();
+        String page = req.getParameter("page");
+        String url;
+        if ("changes".equals(page)) {
+            url = provider.getChangesURL(run);
+        } else if ("test".equals(page)) {
+            String id = req.getParameter("id");
+            if (id == null) {
+                throw new IllegalArgumentException("id parameter not specified");
+            }
+            AbstractTestResultAction action = run.getAction(AbstractTestResultAction.class);
+            if (action == null) {
+                throw new IllegalStateException("No AbstractTestResultAction on this run");
+            }
+            TestResult result = action.findCorrespondingResult(id);
+            url = provider.getTestUrl(result);
+        } else {
+            url = provider.getRunURL(run);
+        }
+        return url;
+    }
+
+    @Extension
+    public static class TransientActionFactoryImpl extends TransientActionFactory {
+        @Override
+        public Class type() {
+            return Run.class;
+        }
+
+        @Nonnull
+        @Override
+        public Collection<? extends Action> createFor(@Nonnull Object target) {
+            return ImmutableList.of(new RunDisplayAction((Run) target));
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/JenkinsRuleWithLocalPort.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/JenkinsRuleWithLocalPort.java
@@ -1,0 +1,12 @@
+package org.jenkinsci.plugins.displayurlapi;
+
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * {@link JenkinsRule} that exposes the local port number
+ */
+public class JenkinsRuleWithLocalPort extends JenkinsRule {
+    public int getLocalPort() {
+        return this.localPort;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/AbstractActionRedirectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/AbstractActionRedirectTest.java
@@ -1,0 +1,30 @@
+package org.jenkinsci.plugins.displayurlapi.actions;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Job;
+import hudson.model.Run;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+import org.jenkinsci.plugins.displayurlapi.JenkinsRuleWithLocalPort;
+import org.junit.Before;
+import org.junit.Rule;
+import org.jvnet.hudson.test.MockFolder;
+
+public abstract class AbstractActionRedirectTest {
+    protected Job job;
+    protected Run<?, ?> run;
+    protected DisplayURLProvider provider;
+
+    @Rule
+    public JenkinsRuleWithLocalPort rule = new JenkinsRuleWithLocalPort();
+
+    @Before
+    public void createJobAndRun() throws Exception {
+        MockFolder folder = rule.createFolder("my folder");
+        FreeStyleProject job = (FreeStyleProject) folder.createProject(FreeStyleProject.DESCRIPTOR, "my job", false);
+        this.job = job;
+        this.run = job.scheduleBuild2(0).get();
+        provider = DisplayURLProvider.get();
+    }
+
+    protected abstract DisplayURLProvider getRedirectedProvider();
+}

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectClassicTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectClassicTest.java
@@ -1,0 +1,49 @@
+package org.jenkinsci.plugins.displayurlapi.actions;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+import org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletResponse;
+
+import static io.restassured.RestAssured.given;
+
+public class ActionRedirectClassicTest extends AbstractActionRedirectTest {
+
+    @Test
+    public void testRedirectForJobURL() throws Exception {
+        given()
+            .urlEncodingEnabled(false)
+            .redirects().follow(false)
+            .when().get(provider.getJobURL(job)).then()
+            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+            .header("Location", getRedirectedProvider().getJobURL(job));
+    }
+
+    @Test
+    public void testRedirectForRunURL() throws Exception {
+        given()
+            .urlEncodingEnabled(false)
+            .redirects().follow(false)
+            .when().get(provider.getRunURL(run)).then()
+            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+            .header("Location", getRedirectedProvider().getRunURL(run));
+    }
+
+    @Test
+    public void testRedirectForChangesURL() throws Exception {
+        given()
+            .urlEncodingEnabled(false)
+            .redirects().follow(false)
+            .when().get(provider.getChangesURL(run)).then()
+            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+            .header("Location", getRedirectedProvider().getChangesURL(run));
+    }
+
+    @Override
+    protected DisplayURLProvider getRedirectedProvider() {
+        return Iterables.find(DisplayURLProvider.all(), Predicates.instanceOf(ClassicDisplayURLProvider.class));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
@@ -1,0 +1,110 @@
+package org.jenkinsci.plugins.displayurlapi.actions;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.tasks.test.AbstractTestResultAction;
+import hudson.tasks.test.TestResult;
+import org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+import org.junit.Test;
+import org.jvnet.hudson.test.TestExtension;
+
+import javax.servlet.http.HttpServletResponse;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
+    @Test
+    public void testRedirectForJobURL() throws Exception {
+        given()
+            .urlEncodingEnabled(false)
+            .redirects().follow(false)
+            .when().get(provider.getJobURL(job)).then()
+            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+            .header("Location", getRedirectedProvider().getJobURL(job));
+    }
+
+    @Test
+    public void testRedirectForRunURL() throws Exception {
+        given()
+            .urlEncodingEnabled(false)
+            .redirects().follow(false)
+            .when().get(provider.getRunURL(run)).then()
+            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+            .header("Location", getRedirectedProvider().getRunURL(run));
+    }
+
+    @Test
+    public void testRedirectForChangesURL() throws Exception {
+        given()
+            .urlEncodingEnabled(false)
+            .redirects().follow(false)
+            .when().get(provider.getChangesURL(run)).then()
+            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+            .header("Location", getRedirectedProvider().getChangesURL(run));
+    }
+
+    @Test
+    public void testUrls() throws Exception {
+        String root = DisplayURLProvider.get().getRoot();
+        assertEquals("http://localhost:" + rule.getLocalPort() + "/jenkins/", root);
+        assertEquals(root + "job/my%20folder/job/my%20job/1/another", getRedirectedProvider().getRunURL(run));
+        assertEquals(root + "job/my%20folder/job/my%20job/another", getRedirectedProvider().getJobURL(job));
+        assertEquals(root + "job/my%20folder/job/my%20job/changesanother", getRedirectedProvider().getChangesURL(run));
+    }
+
+    @Test
+    public void testGetTestUrl() throws Exception {
+        TestResult result = mock(TestResult.class);
+
+        AbstractTestResultAction action = mock(AbstractTestResultAction.class);
+        when(action.getUrlName()).thenReturn("action");
+
+        when(result.getRun()).thenReturn((Run)run);
+        when(result.getTestResultAction()).thenReturn(action);
+        when(result.getUrl()).thenReturn("/some id with spaces");
+
+        String testUrl = getRedirectedProvider().getTestUrl(result);
+        assertEquals("http://localhost:" + rule.getLocalPort() + "/jenkins/job/my%20folder/job/my%20job/1/action/some%20id%20with%20spacesanother", testUrl);
+    }
+
+    @Override
+    protected DisplayURLProvider getRedirectedProvider() {
+        return Iterables.find(DisplayURLProvider.all(), Predicates.instanceOf(AnotherDisplayURLProvider.class));
+    }
+
+    @TestExtension
+    public static class AnotherDisplayURLProvider extends DisplayURLProvider {
+
+        public static final String EXTRA_CONTENT_IN_URL = "another";
+
+        DisplayURLProvider getClassicProvider() {
+            return Iterables.find(DisplayURLProvider.all(), Predicates.instanceOf(ClassicDisplayURLProvider.class));
+        }
+
+        @Override
+        public String getRunURL(Run<?, ?> run) {
+            return getClassicProvider().getRunURL(run) + EXTRA_CONTENT_IN_URL;
+        }
+
+        @Override
+        public String getChangesURL(Run<?, ?> run) {
+            return getClassicProvider().getChangesURL(run) + EXTRA_CONTENT_IN_URL;
+        }
+
+        @Override
+        public String getJobURL(Job<?, ?> project) {
+            return getClassicProvider().getJobURL(project) + EXTRA_CONTENT_IN_URL;
+        }
+
+        @Override
+        public String getTestUrl(hudson.tasks.test.TestResult result) {
+            return getClassicProvider().getTestUrl(result) + EXTRA_CONTENT_IN_URL;
+        }
+    }
+}


### PR DESCRIPTION
[JENKINS-40207](https://issues.jenkins-ci.org/browse/JENKINS-40207)

If you uninstall blue ocean all of the issued links still point to Blue Ocean. Instead we should land visitors on a well known URL and then redirect them based on the available providers.