### PR TITLE
JENKINS-39580 Allow the user to configure a preferred provider 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <!--<jenkins.version>1.625.3</jenkins.version>-->
-    <jenkins.version>2.7.1</jenkins.version>
+    <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
     <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,8 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>1.625.3</jenkins.version>
+    <!--<jenkins.version>1.625.3</jenkins.version>-->
+    <jenkins.version>2.7.1</jenkins.version>
     <java.level>7</java.level>
     <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
   </properties>

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
@@ -13,6 +13,12 @@ import hudson.tasks.test.TestObject;
  */
 @Extension
 public class ClassicDisplayURLProvider extends DisplayURLProvider {
+
+    @Override
+    public String getDisplayName() {
+        return "Jenkins Classic";
+    }
+
     @Override
     public String getRunURL(Run<?, ?> run) {
         return getRoot() + Util.encode(run.getUrl());

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
@@ -16,7 +16,7 @@ public class ClassicDisplayURLProvider extends DisplayURLProvider {
 
     @Override
     public String getDisplayName() {
-        return "Jenkins Classic";
+        return Messages.classic_name();
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.displayurlapi;
 
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
 import hudson.ExtensionPoint;
 import hudson.Util;
 import hudson.model.Job;
@@ -24,6 +26,10 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
         return getJenkins().getExtensionList(DisplayURLProvider.class);
     }
 
+    public static DisplayURLProvider getDefault() {
+        return Iterables.find(all(), Predicates.instanceOf(ClassicDisplayURLProvider.class));
+    }
+
     /** Fully qualified URL for the Root display URL */
     public String getRoot() {
         String root = getJenkins().getRootUrl();
@@ -31,6 +37,11 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
             root = "http://unconfigured-jenkins-location/";
         }
         return Util.encode(root);
+    }
+
+    /** Display name of this provider e.g. "Jenkins Classic", "Blue Ocean", etc */
+    public String getDisplayName() {
+        return this.getClass().getSimpleName();
     }
 
     /** Fully qualified URL for a Run */

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/AbstractDisplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/AbstractDisplayAction.java
@@ -3,8 +3,10 @@ package org.jenkinsci.plugins.displayurlapi.actions;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import hudson.model.Action;
+import hudson.model.User;
 import org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+import org.jenkinsci.plugins.displayurlapi.user.PreferredProviderUserProperty;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -39,9 +41,13 @@ public abstract class AbstractDisplayAction implements Action {
     protected abstract String getRedirectURL(DisplayURLProvider provider);
 
     DisplayURLProvider lookupProvider() {
-        Iterable<DisplayURLProvider> all = DisplayURLProvider.all();
-        DisplayURLProvider defaultProvider = Iterables.find(all, Predicates.instanceOf(ClassicDisplayURLProvider.class));
-        Iterable<DisplayURLProvider> availableProviders = Iterables.filter(all, Predicates.not(Predicates.instanceOf(ClassicDisplayURLProvider.class)));
-        return Iterables.getFirst(availableProviders, defaultProvider);
+        User current = User.current();
+        DisplayURLProvider provider = current.getProperty(PreferredProviderUserProperty.class).getConfiguredProvider();
+        if (provider == null) {
+            Iterable<DisplayURLProvider> all = DisplayURLProvider.all();
+            Iterable<DisplayURLProvider> availableProviders = Iterables.filter(all, Predicates.not(Predicates.instanceOf(ClassicDisplayURLProvider.class)));
+            provider = Iterables.getFirst(availableProviders, DisplayURLProvider.getDefault());
+        }
+        return provider;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty.java
@@ -1,0 +1,78 @@
+package org.jenkinsci.plugins.displayurlapi.user;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import hudson.Extension;
+import hudson.model.UserProperty;
+import hudson.model.UserPropertyDescriptor;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class PreferredProviderUserProperty extends UserProperty {
+
+    @Extension
+    public static final UserPropertyDescriptor DESCRIPTOR = new PreferredProviderUserPropertyDescriptor();
+
+    @Nullable
+    private String providerId;
+
+    @DataBoundConstructor
+    public PreferredProviderUserProperty(@Nullable String providerId) {
+        this.providerId = providerId;
+    }
+
+    public ProviderOption getProvider() {
+        final DisplayURLProvider provider = getConfiguredProvider();
+        return provider == null ? ProviderOption.DEFAULT_OPTION : new ProviderOption(provider.getClass().getName(), provider.getDisplayName());
+    }
+
+    public DisplayURLProvider getConfiguredProvider() {
+        return Iterables.find(DisplayURLProvider.all(), new Predicate<DisplayURLProvider>() {
+            @Override
+            public boolean apply(DisplayURLProvider input) {
+                return input.getClass().getName().equals(providerId);
+            }
+        }, null);
+    }
+
+    public List<ProviderOption> getAll() {
+        Iterable<ProviderOption> options = Iterables.transform(DisplayURLProvider.all(), new Function<DisplayURLProvider, ProviderOption>() {
+            @Override
+            public ProviderOption apply(DisplayURLProvider input) {
+                return new ProviderOption(input.getClass().getName(), input.getDisplayName());
+            }
+        });
+        return ImmutableList.copyOf(Iterables.concat(Lists.newArrayList(ProviderOption.DEFAULT_OPTION), options));
+    }
+
+    public boolean isSelected(String providerId) {
+        return getProvider().getId().equals(providerId);
+    }
+
+    public static class ProviderOption {
+
+        public static final ProviderOption DEFAULT_OPTION = new ProviderOption("default", "Default");
+
+        private final String id;
+        private final String name;
+
+        public ProviderOption(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserPropertyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserPropertyDescriptor.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.displayurlapi.user;
 import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
+import org.jenkinsci.plugins.displayurlapi.Messages;
 import org.jenkinsci.plugins.displayurlapi.user.PreferredProviderUserProperty.ProviderOption;
 
 public class PreferredProviderUserPropertyDescriptor extends UserPropertyDescriptor {
@@ -18,6 +19,6 @@ public class PreferredProviderUserPropertyDescriptor extends UserPropertyDescrip
 
     @Override
     public String getDisplayName() {
-        return "Preferred UI";
+        return Messages.display_url();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserPropertyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserPropertyDescriptor.java
@@ -1,0 +1,23 @@
+package org.jenkinsci.plugins.displayurlapi.user;
+
+import hudson.model.User;
+import hudson.model.UserProperty;
+import hudson.model.UserPropertyDescriptor;
+import org.jenkinsci.plugins.displayurlapi.user.PreferredProviderUserProperty.ProviderOption;
+
+public class PreferredProviderUserPropertyDescriptor extends UserPropertyDescriptor {
+
+    public PreferredProviderUserPropertyDescriptor() {
+        super(PreferredProviderUserProperty.class);
+    }
+
+    @Override
+    public UserProperty newInstance(User user) {
+        return new PreferredProviderUserProperty(ProviderOption.DEFAULT_OPTION.getId());
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Preferred UI";
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/displayurlapi/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/displayurlapi/Messages.properties
@@ -1,0 +1,2 @@
+display.url = Notification URL
+classic.name = Jenkins Classic

--- a/src/main/resources/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty/config.jelly
@@ -1,0 +1,20 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:block>
+    <f:entry name="providerId" title="Preferred UI" field="providerId">
+        <select name="providerId">
+            <j:forEach var="provider" items="${instance.all}">
+                <j:choose>
+                   <j:when test="${instance.isSelected(provider.getId())}">
+                     <option value="${provider.getId()}" selected="true">${provider.getName()}</option>
+                   </j:when>
+                   <j:otherwise>
+                     <option value="${provider.getId()}">${provider.getName()}</option>
+                   </j:otherwise>
+                </j:choose>
+            </j:forEach>
+        </select>
+    </f:entry>
+  </f:block>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty/config.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:block>
-    <f:entry name="providerId" title="Preferred UI" field="providerId">
+    <f:entry name="providerId" field="providerId">
         <select name="providerId">
             <j:forEach var="provider" items="${instance.all}">
                 <j:choose>

--- a/src/main/resources/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty/help-providerId.html
+++ b/src/main/resources/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty/help-providerId.html
@@ -1,0 +1,1 @@
+Allows the user to select their preferred user interface when clicking links to Jenkins from notifications (e.g. Email, Slack or Github)

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
@@ -6,7 +6,6 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
-import org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.junit.Test;
 import org.jvnet.hudson.test.TestExtension;
@@ -83,28 +82,24 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
 
         public static final String EXTRA_CONTENT_IN_URL = "another";
 
-        DisplayURLProvider getClassicProvider() {
-            return Iterables.find(DisplayURLProvider.all(), Predicates.instanceOf(ClassicDisplayURLProvider.class));
-        }
-
         @Override
         public String getRunURL(Run<?, ?> run) {
-            return getClassicProvider().getRunURL(run) + EXTRA_CONTENT_IN_URL;
+            return DisplayURLProvider.getDefault().getRunURL(run) + EXTRA_CONTENT_IN_URL;
         }
 
         @Override
         public String getChangesURL(Run<?, ?> run) {
-            return getClassicProvider().getChangesURL(run) + EXTRA_CONTENT_IN_URL;
+            return DisplayURLProvider.getDefault().getChangesURL(run) + EXTRA_CONTENT_IN_URL;
         }
 
         @Override
         public String getJobURL(Job<?, ?> project) {
-            return getClassicProvider().getJobURL(project) + EXTRA_CONTENT_IN_URL;
+            return DisplayURLProvider.getDefault().getJobURL(project) + EXTRA_CONTENT_IN_URL;
         }
 
         @Override
         public String getTestUrl(hudson.tasks.test.TestResult result) {
-            return getClassicProvider().getTestUrl(result) + EXTRA_CONTENT_IN_URL;
+            return DisplayURLProvider.getDefault().getTestUrl(result) + EXTRA_CONTENT_IN_URL;
         }
     }
 }


### PR DESCRIPTION
[JENKINS-39580](https://issues.jenkins-ci.org/browse/JENKINS-39580)

Allows the user to set their preferred UI in the users settings

Depends on https://github.com/jenkinsci/display-url-api-plugin/pull/4

![user admin istrator configuration jenkins 2016-12-04 13-41-22](https://cloud.githubusercontent.com/assets/50156/20863701/6a72a3c4-ba27-11e6-90c8-9843f1c3b82a.png)
