### PR TITLE
Plugin does not seem to require such a new Jenkins core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>1.625.3</jenkins.version>
+    <jenkins.version>1.609.3</jenkins.version>
     <java.level>7</java.level>
     <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
   </properties>


### PR DESCRIPTION
I do not know why such a new Jenkins core is required but this plugin only prevent multibranch + github-branch-source to be installed.