### PR TITLE
Switch to using a non-deprecated way of getting the descriptor.

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProviderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProviderTest.java
@@ -23,7 +23,7 @@ public class DisplayURLProviderTest {
     @Test
     public void urls() throws Exception {
         MockFolder folder = rule.createFolder("my folder");
-        FreeStyleProject project = (FreeStyleProject) folder.createProject(FreeStyleProject.DESCRIPTOR, "my job", false);
+        FreeStyleProject project = (FreeStyleProject) folder.createProject(rule.jenkins.getDescriptorByType(FreeStyleProject.DescriptorImpl.class), "my job", false);
         Run<?, ?> run = project.scheduleBuild2(0).get();
 
         String root = DisplayURLProvider.get().getRoot();
@@ -42,7 +42,7 @@ public class DisplayURLProviderTest {
     public void testGetTestURL() throws Exception {
 
         MockFolder folder = rule.createFolder("my folder");
-        FreeStyleProject project = (FreeStyleProject) folder.createProject(FreeStyleProject.DESCRIPTOR, "my job", false);
+        FreeStyleProject project = (FreeStyleProject) folder.createProject(rule.jenkins.getDescriptorByType(FreeStyleProject.DescriptorImpl.class), "my job", false);
         Run<?, ?> run = project.scheduleBuild2(0).get();
         MockTestResult result = new MockTestResult(run);
 

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/AbstractActionRedirectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/AbstractActionRedirectTest.java
@@ -20,7 +20,7 @@ public abstract class AbstractActionRedirectTest {
     @Before
     public void createJobAndRun() throws Exception {
         MockFolder folder = rule.createFolder("my folder");
-        FreeStyleProject job = (FreeStyleProject) folder.createProject(FreeStyleProject.DESCRIPTOR, "my job", false);
+        FreeStyleProject job = (FreeStyleProject) folder.createProject(rule.jenkins.getDescriptorByType(FreeStyleProject.DescriptorImpl.class), "my job", false);
         this.job = job;
         this.run = job.scheduleBuild2(0).get();
         provider = DisplayURLProvider.get();


### PR DESCRIPTION
FreeStyleProject.DESCRIPTOR is deprecated, so use the non-deprecated method for getting a descriptor.