### PR TITLE
JENKINS-43538 API change: remove getTestUrl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <relativePath />
   </parent>
   <artifactId>display-url-api</artifactId>
-  <version>1.1.2-SNAPSHOT</version>
+  <version>1.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <properties>
@@ -58,11 +58,6 @@
   </pluginRepositories>
 
   <dependencies>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>junit</artifactId>
-      <version>1.19</version>
-    </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <relativePath />
   </parent>
   <artifactId>display-url-api</artifactId>
-  <version>1.2-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <properties>

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
@@ -4,9 +4,6 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.Job;
 import hudson.model.Run;
-import hudson.tasks.junit.TestResult;
-import hudson.tasks.test.AbstractTestResultAction;
-import hudson.tasks.test.TestObject;
 
 /**
  * Display URL Provider for the Classical Jenkins UI
@@ -32,35 +29,5 @@ public class ClassicDisplayURLProvider extends DisplayURLProvider {
     @Override
     public String getJobURL(Job<?, ?> job) {
         return getRoot() + Util.encode(job.getUrl());
-    }
-
-    @Override
-    public String getTestUrl(hudson.tasks.test.TestResult result) {
-        String buildUrl = getRunURL(result.getRun());
-        AbstractTestResultAction action = result.getTestResultAction();
-
-        TestObject parent = result.getParent();
-        TestResult testResultRoot = null;
-        while(parent != null) {
-            if (parent instanceof TestResult) {
-                testResultRoot = (TestResult) parent;
-                break;
-            }
-            parent = parent.getParent();
-        }
-
-        String testUrl = action.getUrlName()
-                + (testResultRoot != null ? testResultRoot.getUrl() : "")
-                + result.getUrl();
-
-        String[] pathComponents = testUrl.split("/");
-        StringBuilder buf = new StringBuilder();
-        for (String c : pathComponents) {
-            buf.append(Util.rawEncode(c)).append('/');
-        }
-        // remove last /
-        buf.deleteCharAt(buf.length() - 1);
-
-        return buildUrl + buf.toString();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.displayurlapi;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.ExtensionPoint;
 import hudson.Util;
 import hudson.model.Job;
@@ -71,14 +70,6 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
     /** Fully qualified URL for a Jobs home */
     public abstract String getJobURL(Job<?, ?> job);
 
-    /** Fully qualified URL to the test details page for a given test result */
-    public abstract String getTestUrl(hudson.tasks.test.TestResult result);
-
-    /** Fully qualified URL to the test details page for a given test result. Alternate name for consistency. See JENKINS-41802. */
-    public String getTestURL(hudson.tasks.test.TestResult result) {
-        return getTestUrl(result);
-    }
-
     static class DisplayURLProviderImpl extends ClassicDisplayURLProvider {
 
         public static final DisplayURLProvider INSTANCE = new DisplayURLProviderImpl();
@@ -98,13 +89,6 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
         @Override
         public String getJobURL(Job<?, ?> job) {
             return super.getJobURL(job) + DISPLAY_POSTFIX;
-        }
-
-        @Override
-        @SuppressFBWarnings(value = "NM_VERY_CONFUSING", justification = "getTestURL was introduced for consistency")
-        public String getTestUrl(hudson.tasks.test.TestResult result) {
-            Run<?, ?> run = result.getRun();
-            return super.getRunURL(run) + DISPLAY_POSTFIX + "?page=test&id=" + Util.rawEncode(result.getId());
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/RunDisplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/RunDisplayAction.java
@@ -4,8 +4,6 @@ import com.google.common.collect.ImmutableList;
 import hudson.Extension;
 import hudson.model.Action;
 import hudson.model.Run;
-import hudson.tasks.test.AbstractTestResultAction;
-import hudson.tasks.test.TestResult;
 import jenkins.model.TransientActionFactory;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.kohsuke.stapler.Stapler;
@@ -28,17 +26,6 @@ public class RunDisplayAction extends AbstractDisplayAction {
         String url;
         if ("changes".equals(page)) {
             url = provider.getChangesURL(run);
-        } else if ("test".equals(page)) {
-            String id = req.getParameter("id");
-            if (id == null) {
-                throw new IllegalArgumentException("id parameter not specified");
-            }
-            AbstractTestResultAction action = run.getAction(AbstractTestResultAction.class);
-            if (action == null) {
-                throw new IllegalStateException("No AbstractTestResultAction on this run");
-            }
-            TestResult result = action.findCorrespondingResult(id);
-            url = provider.getTestUrl(result);
         } else {
             url = provider.getRunURL(run);
         }

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProviderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProviderTest.java
@@ -3,17 +3,11 @@ package org.jenkinsci.plugins.displayurlapi;
 import hudson.EnvVars;
 import hudson.model.FreeStyleProject;
 import hudson.model.Run;
-import hudson.tasks.test.AbstractTestResultAction;
-import hudson.tasks.test.TestObject;
-import hudson.tasks.test.TestResult;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.MockFolder;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class DisplayURLProviderTest {
 
@@ -36,56 +30,5 @@ public class DisplayURLProviderTest {
         assertEquals(DisplayURLProvider.get().getRunURL(run), environment.get("RUN_DISPLAY_URL"));
         assertEquals(DisplayURLProvider.get().getChangesURL(run), environment.get("RUN_CHANGES_DISPLAY_URL"));
         assertEquals(DisplayURLProvider.get().getJobURL(project), environment.get("JOB_DISPLAY_URL"));
-    }
-
-    @Test
-    public void testGetTestURL() throws Exception {
-
-        MockFolder folder = rule.createFolder("my folder");
-        FreeStyleProject project = (FreeStyleProject) folder.createProject(rule.jenkins.getDescriptorByType(FreeStyleProject.DescriptorImpl.class), "my job", false);
-        Run<?, ?> run = project.scheduleBuild2(0).get();
-        MockTestResult result = new MockTestResult(run);
-
-        AbstractTestResultAction action = mock(AbstractTestResultAction.class);
-        when(action.getUrlName()).thenReturn("action");
-        when(action.findCorrespondingResult(anyString())).thenReturn(result);
-
-        String testUrl = DisplayURLProvider.get().getTestUrl(result);
-
-        assertEquals("http://localhost:" + rule.getLocalPort() + "/jenkins/job/my%20folder/job/my%20job/1/display/redirect?page=test&id=some%20id%20with%20spaces", testUrl);
-    }
-
-    class MockTestResult extends TestResult {
-
-        private final Run<?, ?> owner;
-
-        public MockTestResult(Run<?, ?> owner) {
-            this.owner = owner;
-        }
-
-        @Override
-        public String getName() {
-            return "some id with spaces";
-        }
-
-        @Override
-        public Run<?, ?> getRun() {
-            return owner;
-        }
-
-        @Override
-        public TestObject getParent() {
-            return null;
-        }
-
-        @Override
-        public TestResult findCorrespondingResult(String id) {
-            return null;
-        }
-
-        @Override
-        public String getDisplayName() {
-            return null;
-        }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectEligibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectEligibilityTest.java
@@ -104,11 +104,6 @@ public class ActionRedirectEligibilityTest extends AbstractActionRedirectTest {
         public String getJobURL(Job<?, ?> project) {
             return ELIGIBLE_IN_URL;
         }
-
-        @Override
-        public String getTestUrl(hudson.tasks.test.TestResult result) {
-            return ELIGIBLE_IN_URL;
-        }
     }
 
     @TestExtension

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
@@ -4,8 +4,6 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import hudson.model.Job;
 import hudson.model.Run;
-import hudson.tasks.test.AbstractTestResultAction;
-import hudson.tasks.test.TestResult;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.junit.Test;
 import org.jvnet.hudson.test.TestExtension;
@@ -14,8 +12,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
     @Test
@@ -57,20 +53,6 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
         assertEquals(root + "job/my%20folder/job/my%20job/changesanother", getRedirectedProvider().getChangesURL(run));
     }
 
-    @Test
-    public void testGetTestUrl() throws Exception {
-        TestResult result = mock(TestResult.class);
-
-        AbstractTestResultAction action = mock(AbstractTestResultAction.class);
-        when(action.getUrlName()).thenReturn("action");
-
-        when(result.getRun()).thenReturn((Run)run);
-        when(result.getTestResultAction()).thenReturn(action);
-        when(result.getUrl()).thenReturn("/some id with spaces");
-
-        String testUrl = getRedirectedProvider().getTestUrl(result);
-        assertEquals("http://localhost:" + rule.getLocalPort() + "/jenkins/job/my%20folder/job/my%20job/1/action/some%20id%20with%20spacesanother", testUrl);
-    }
 
     @Override
     protected DisplayURLProvider getRedirectedProvider() {
@@ -95,11 +77,6 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
         @Override
         public String getJobURL(Job<?, ?> project) {
             return DisplayURLProvider.getDefault().getJobURL(project) + EXTRA_CONTENT_IN_URL;
-        }
-
-        @Override
-        public String getTestUrl(hudson.tasks.test.TestResult result) {
-            return DisplayURLProvider.getDefault().getTestUrl(result) + EXTRA_CONTENT_IN_URL;
         }
     }
 }


### PR DESCRIPTION
Removes all trace of JUnit getTestUrl but might have unknown downstream effects. The alternative is a big refactor to the `junit-plugin` which will cause ABI incompatibilities. Lesser of two evils I suppose. 

Whoever split JUnit out of core owes a follow up to do this properly and split the `junit.tasks.tests` package into its own plugin instead of leaving it in a mess.

![5346515 _c752f8d6b04b7e4061516847d535ef73](https://cloud.githubusercontent.com/assets/50156/24988208/d7d3c750-2047-11e7-8404-e7da77d544ca.jpg)

@reviewbybees @jglick @oleg-nenashev 

This plugin and https://github.com/jenkinsci/blueocean-display-url-plugin/pull/5 need to be merged and released at the same time in order not to break Blue Ocean users at a very minimum. 