### PR TITLE
Java 11 readiness: Make plugin also buildable on JDK11 and Jenkins 2.164.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,1 @@
-pipeline {
-  agent {
-    docker {
-      image 'maven'
-    }
-    
-  }
-  stages {
-    stage('Build') {
-      steps {
-        sh 'mvn clean install'
-      }
-    }
-  }
-}
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
   <properties>
     <jenkins.version>2.89.4</jenkins.version>
     <java.level>8</java.level>
-    <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
   </properties>
 
   <name>Display URL API</name>
@@ -59,12 +58,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>command-launcher</artifactId>
-      <version>1.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>2.7.6</version>
@@ -88,6 +81,12 @@
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
       <version>2.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId> <!-- forced bc RequireUpperBoundDeps -->
+      <artifactId>commons-lang3</artifactId>
+      <version>3.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>command-launcher</artifactId>
       <version>1.3</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,10 @@
           <groupId>com.sun.xml.bind</groupId>
           <artifactId>jaxb-osgi</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId> <!-- forced bc RequireUpperBoundDeps, pulled by JTH -->
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -81,12 +85,6 @@
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
       <version>2.3.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId> <!-- forced bc RequireUpperBoundDeps -->
-      <artifactId>commons-lang3</artifactId>
-      <version>3.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.28</version>
+    <version>3.40</version>
     <relativePath />
   </parent>
   <artifactId>display-url-api</artifactId>
@@ -13,8 +13,8 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>1.609.3</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>2.89.4</jenkins.version>
+    <java.level>8</java.level>
     <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
   </properties>
 
@@ -59,6 +59,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>command-launcher</artifactId>
+      <version>1.3</version>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>2.7.6</version>
@@ -67,7 +72,21 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.0.2</version>
+      <version>3.3.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-osgi</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <!-- forcing 2.3.0 in dep for rest-assured to avoid systemPath issue on JDK11,
+      see https://github.com/jenkinsci/jaxb-plugin/pull/6 for more information -->
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
By bumping the baseline to 2.89.4, we're past 2.86 where the command-launcher plugin and the eponym API was extracted.

The PR will fail until merged, because the Jenkinsfile on master must be fixed, and the Jenkinsfile I'm proposing here is not used yet because I'm not a committer on this repo.

@stephenc as current maintainer, AFAICT looking at last commits, cc @jenkinsci/java11-support 