### PR TITLE
[JENKINS-53179] Extend env variable to facilitate the access to the tests/artifacts URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ target
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Generated folder when running mvn hpi:run
+work

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
@@ -32,6 +32,11 @@ public class ClassicDisplayURLProvider extends DisplayURLProvider {
     }
 
     @Override
+    public String getTestsURL(Run<?, ?> run) {
+        return "";
+    }
+
+    @Override
     public String getArtifactsURL(Run<?, ?> run) {
         return getRunURL(run) + "artifact";
     }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
@@ -5,7 +5,6 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.Job;
 import hudson.model.Run;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Display URL Provider for the Classical Jenkins UI
@@ -40,7 +39,7 @@ public class ClassicDisplayURLProvider extends DisplayURLProvider {
     @Override
     @NonNull
     public String getTestsURL(Run<?, ?> run) {
-        return getRunURL(run) + this.getTestsFolder();
+        return getRunURL(run) + "testReport";
     }
 
     @Override
@@ -48,14 +47,4 @@ public class ClassicDisplayURLProvider extends DisplayURLProvider {
     public String getJobURL(Job<?, ?> job) {
         return getRoot() + Util.encode(job.getUrl());
     }
-
-    private String getTestsFolder() {
-        String folder = System.getProperty(JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER_PROP);
-        if (StringUtils.isEmpty(folder)) {
-            folder = "testReport";
-        }
-        return folder;
-    }
-
-    private static final String JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER_PROP = "jenkins.classic.displayurl.tests.folder";
 }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
@@ -27,18 +27,18 @@ public class ClassicDisplayURLProvider extends DisplayURLProvider {
     }
 
     @Override
+    public String getArtifactsURL(Run<?, ?> run) {
+        return getRunURL(run) + "artifact";
+    }
+
+    @Override
     public String getChangesURL(Run<?, ?> run) {
         return getJobURL(run.getParent()) + "changes";
     }
 
     @Override
     public String getTestsURL(Run<?, ?> run) {
-        return "";
-    }
-
-    @Override
-    public String getArtifactsURL(Run<?, ?> run) {
-        return getRunURL(run) + "artifact";
+        return getRunURL(run) + super.getTestsFolder();
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
@@ -4,6 +4,7 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.Job;
 import hudson.model.Run;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Display URL Provider for the Classical Jenkins UI
@@ -38,11 +39,25 @@ public class ClassicDisplayURLProvider extends DisplayURLProvider {
 
     @Override
     public String getTestsURL(Run<?, ?> run) {
-        return getRunURL(run) + super.getTestsFolder();
+        return getRunURL(run) + this.getTestsFolder();
     }
 
     @Override
     public String getJobURL(Job<?, ?> job) {
         return getRoot() + Util.encode(job.getUrl());
     }
+
+    private String getTestsFolder() {
+        String folder = System.getenv(JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER_ENV);
+        if (StringUtils.isEmpty(folder)) {
+            folder = System.getProperty(JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER_PROP);
+        }
+        if (StringUtils.isEmpty(folder)) {
+            folder = StringUtils.EMPTY;
+        }
+        return folder;
+    }
+
+    private static final String JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER_ENV = "JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER";
+    private static final String JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER_PROP = "jenkins.classic.displayurl.tests.folder";
 }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
@@ -53,7 +53,7 @@ public class ClassicDisplayURLProvider extends DisplayURLProvider {
             folder = System.getProperty(JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER_PROP);
         }
         if (StringUtils.isEmpty(folder)) {
-            folder = StringUtils.EMPTY;
+            folder = "testReport";
         }
         return folder;
     }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
@@ -32,6 +32,11 @@ public class ClassicDisplayURLProvider extends DisplayURLProvider {
     }
 
     @Override
+    public String getArtifactsURL(Run<?, ?> run) {
+        return getRunURL(run) + "artifact";
+    }
+
+    @Override
     public String getJobURL(Job<?, ?> job) {
         return getRoot() + Util.encode(job.getUrl());
     }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
@@ -48,16 +48,12 @@ public class ClassicDisplayURLProvider extends DisplayURLProvider {
     }
 
     private String getTestsFolder() {
-        String folder = System.getenv(JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER_ENV);
-        if (StringUtils.isEmpty(folder)) {
-            folder = System.getProperty(JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER_PROP);
-        }
+        String folder = System.getProperty(JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER_PROP);
         if (StringUtils.isEmpty(folder)) {
             folder = "testReport";
         }
         return folder;
     }
 
-    private static final String JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER_ENV = "JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER";
     private static final String JENKINS_CLASSIC_DISPLAYURL_TESTS_FOLDER_PROP = "jenkins.classic.displayurl.tests.folder";
 }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/ClassicDisplayURLProvider.java
@@ -28,11 +28,6 @@ public class ClassicDisplayURLProvider extends DisplayURLProvider {
     }
 
     @Override
-    public String getArtifactsURL(Run<?, ?> run) {
-        return getRunURL(run) + "artifact";
-    }
-
-    @Override
     public String getChangesURL(Run<?, ?> run) {
         return getJobURL(run.getParent()) + "changes";
     }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
@@ -180,18 +180,6 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
         }
         return clazz;
     }
-
-    protected String getTestsFolder() {
-        String folder = System.getenv(JENKINS_DISPLAYURL_TESTS_FOLDER_ENV);
-        if (StringUtils.isEmpty(folder)) {
-            folder = System.getProperty(JENKINS_DISPLAYURL_TESTS_FOLDER_PROP);
-        }
-        if (StringUtils.isEmpty(folder)) {
-            folder = StringUtils.EMPTY;
-        }
-        return folder;
-    }
-
     @Nullable
     public static DisplayURLProvider getPreferredProvider() {
         String clazz = findClass();
@@ -203,7 +191,4 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
 
     private static final String JENKINS_DISPLAYURL_PROVIDER_ENV = "JENKINS_DISPLAYURL_PROVIDER";
     private static final String JENKINS_DISPLAYURL_PROVIDER_PROP = "jenkins.displayurl.provider";
-
-    private static final String JENKINS_DISPLAYURL_TESTS_FOLDER_ENV = "JENKINS_DISPLAYURL_TESTS_FOLDER";
-    private static final String JENKINS_DISPLAYURL_TESTS_FOLDER_PROP = "jenkins.displayurl.tests.folder";
 }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
@@ -116,46 +116,32 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
             }
         }
 
-        @Override
-        public String getArtifactsURL(Run<?, ?> run) {
+        private String getPageURL(Run<?, ?> run, String page) {
             DisplayURLContext ctx = DisplayURLContext.open();
             try {
                 if (ctx.run() == null) {
                     // the link might be generated from another run so we only add this to the context if unset
                     ctx.run(run);
                 }
-                return DisplayURLDecorator.decorate(ctx, super.getRunURL(run) + DISPLAY_POSTFIX + "?page=artifacts");
+                return DisplayURLDecorator.decorate(ctx, super.getRunURL(run) + DISPLAY_POSTFIX + "?page=" + page);
             } finally {
                 ctx.close();
             }
+        }
+
+        @Override
+        public String getArtifactsURL(Run<?, ?> run) {
+            return getPageURL(run, "artifacts");
         }
 
         @Override
         public String getChangesURL(Run<?, ?> run) {
-            DisplayURLContext ctx = DisplayURLContext.open();
-            try {
-                if (ctx.run() == null) {
-                    // the link might be generated from another run so we only add this to the context if unset
-                    ctx.run(run);
-                }
-                return DisplayURLDecorator.decorate(ctx, super.getRunURL(run) + DISPLAY_POSTFIX + "?page=changes");
-            } finally {
-                ctx.close();
-            }
+            return getPageURL(run, "changes");
         }
 
         @Override
         public String getTestsURL(Run<?, ?> run) {
-            DisplayURLContext ctx = DisplayURLContext.open();
-            try {
-                if (ctx.run() == null) {
-                    // the link might be generated from another run so we only add this to the context if unset
-                    ctx.run(run);
-                }
-                return DisplayURLDecorator.decorate(ctx, super.getRunURL(run) + DISPLAY_POSTFIX + "?page=tests");
-            } finally {
-                ctx.close();
-            }
+            return getPageURL(run, "tests");
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
@@ -75,7 +75,9 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
     /**
      * Fully qualified URL for a page that displays artifacts for a Run.
      */
-    public abstract String getArtifactsURL(Run<?, ?> run);
+    public String getArtifactsURL(Run<?, ?> run) {
+        return getRunURL(run) + "artifact";
+    }
 
     /**
      * Fully qualified URL for a page that displays changes for a project.

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
@@ -73,7 +73,7 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
     public abstract String getRunURL(Run<?, ?> run);
 
     /**
-     * Fully qualified URL for a page that displays artifacts for a project.
+     * Fully qualified URL for a page that displays artifacts for a Run.
      */
     public abstract String getArtifactsURL(Run<?, ?> run);
 
@@ -83,7 +83,7 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
     public abstract String getChangesURL(Run<?, ?> run);
 
     /**
-     * Fully qualified URL for a page that displays tests for a project.
+     * Fully qualified URL for a page that displays tests for a Run.
      */
     public abstract String getTestsURL(Run<?, ?> run);
 

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
@@ -180,6 +180,7 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
         }
         return clazz;
     }
+
     @Nullable
     public static DisplayURLProvider getPreferredProvider() {
         String clazz = findClass();

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
@@ -9,9 +9,6 @@ import hudson.model.Run;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.displayurlapi.actions.AbstractDisplayAction;
-import org.jenkinsci.plugins.displayurlapi.user.PreferredProviderUserProperty;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
@@ -81,6 +78,11 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
     public abstract String getChangesURL(Run<?, ?> run);
 
     /**
+     * Fully qualified URL for a page that displays tests for a project.
+     */
+    public abstract String getTestsURL(Run<?, ?> run);
+
+    /**
      * Fully qualified URL for a page that displays artifacts for a project.
      */
     public abstract String getArtifactsURL(Run<?, ?> run);
@@ -123,6 +125,20 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
                     ctx.run(run);
                 }
                 return DisplayURLDecorator.decorate(ctx, super.getRunURL(run) + DISPLAY_POSTFIX + "?page=changes");
+            } finally {
+                ctx.close();
+            }
+        }
+
+        @Override
+        public String getTestsURL(Run<?, ?> run) {
+            DisplayURLContext ctx = DisplayURLContext.open();
+            try {
+                if (ctx.run() == null) {
+                    // the link might be generated from another run so we only add this to the context if unset
+                    ctx.run(run);
+                }
+                return DisplayURLDecorator.decorate(ctx, super.getRunURL(run) + DISPLAY_POSTFIX + "?page=tests");
             } finally {
                 ctx.close();
             }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
@@ -81,6 +81,11 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
     public abstract String getChangesURL(Run<?, ?> run);
 
     /**
+     * Fully qualified URL for a page that displays artifacts for a project.
+     */
+    public abstract String getArtifactsURL(Run<?, ?> run);
+
+    /**
      * Fully qualified URL for a Jobs home
      */
     public abstract String getJobURL(Job<?, ?> job);
@@ -118,6 +123,20 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
                     ctx.run(run);
                 }
                 return DisplayURLDecorator.decorate(ctx, super.getRunURL(run) + DISPLAY_POSTFIX + "?page=changes");
+            } finally {
+                ctx.close();
+            }
+        }
+
+        @Override
+        public String getArtifactsURL(Run<?, ?> run) {
+            DisplayURLContext ctx = DisplayURLContext.open();
+            try {
+                if (ctx.run() == null) {
+                    // the link might be generated from another run so we only add this to the context if unset
+                    ctx.run(run);
+                }
+                return DisplayURLDecorator.decorate(ctx, super.getRunURL(run) + DISPLAY_POSTFIX + "?page=artifacts");
             } finally {
                 ctx.close();
             }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/EnvironmentContributorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/EnvironmentContributorImpl.java
@@ -21,6 +21,7 @@ public class EnvironmentContributorImpl extends EnvironmentContributor {
             DisplayURLProvider urlProvider = DisplayURLProvider.get();
             envs.put("RUN_DISPLAY_URL", urlProvider.getRunURL(r));
             envs.put("RUN_CHANGES_DISPLAY_URL", urlProvider.getChangesURL(r));
+            envs.put("RUN_ARTIFACTS_DISPLAY_URL", urlProvider.getArtifactsURL(r));
         } finally {
             ctx.close();
         }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/EnvironmentContributorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/EnvironmentContributorImpl.java
@@ -22,7 +22,7 @@ public class EnvironmentContributorImpl extends EnvironmentContributor {
             envs.put("RUN_DISPLAY_URL", urlProvider.getRunURL(r));
             envs.put("RUN_ARTIFACTS_DISPLAY_URL", urlProvider.getArtifactsURL(r));
             envs.put("RUN_CHANGES_DISPLAY_URL", urlProvider.getChangesURL(r));
-            envs.put("RUN_TEST_DISPLAY_URL", urlProvider.getTestsURL(r));
+            envs.put("RUN_TESTS_DISPLAY_URL", urlProvider.getTestsURL(r));
         } finally {
             ctx.close();
         }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/EnvironmentContributorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/EnvironmentContributorImpl.java
@@ -20,8 +20,9 @@ public class EnvironmentContributorImpl extends EnvironmentContributor {
             ctx.plugin(null); // environment contributor "comes from" core
             DisplayURLProvider urlProvider = DisplayURLProvider.get();
             envs.put("RUN_DISPLAY_URL", urlProvider.getRunURL(r));
-            envs.put("RUN_CHANGES_DISPLAY_URL", urlProvider.getChangesURL(r));
             envs.put("RUN_ARTIFACTS_DISPLAY_URL", urlProvider.getArtifactsURL(r));
+            envs.put("RUN_CHANGES_DISPLAY_URL", urlProvider.getChangesURL(r));
+            envs.put("RUN_TEST_DISPLAY_URL", urlProvider.getTestsURL(r));
         } finally {
             ctx.close();
         }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/RunDisplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/RunDisplayAction.java
@@ -28,6 +28,8 @@ public class RunDisplayAction extends AbstractDisplayAction {
             url = provider.getChangesURL(run);
         } else if ("artifacts".equals(page)) {
             url = provider.getArtifactsURL(run);
+        } else if ("tests".equals(page)) {
+            url = provider.getTestsURL(run);
         } else {
             url = provider.getRunURL(run);
         }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/RunDisplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/RunDisplayAction.java
@@ -24,10 +24,10 @@ public class RunDisplayAction extends AbstractDisplayAction {
         StaplerRequest req = Stapler.getCurrentRequest();
         String page = req.getParameter("page");
         String url;
-        if ("changes".equals(page)) {
-            url = provider.getChangesURL(run);
-        } else if ("artifacts".equals(page)) {
+        if ("artifacts".equals(page)) {
             url = provider.getArtifactsURL(run);
+        } else if ("changes".equals(page)) {
+            url = provider.getChangesURL(run);
         } else if ("tests".equals(page)) {
             url = provider.getTestsURL(run);
         } else {

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/RunDisplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/RunDisplayAction.java
@@ -25,12 +25,21 @@ public class RunDisplayAction extends AbstractDisplayAction {
         StaplerRequest req = Stapler.getCurrentRequest();
         String page = req.getParameter("page");
         String url;
-        if ("artifacts".equals(page)) {
-            url = provider.getArtifactsURL(run);
-        } else if ("changes".equals(page)) {
-            url = provider.getChangesURL(run);
-        } else if ("tests".equals(page)) {
-            url = provider.getTestsURL(run);
+        if (page != null) {
+            switch (page) {
+                case "artifacts":
+                    url = provider.getArtifactsURL(run);
+                    break;
+                case "changes":
+                    url = provider.getChangesURL(run);
+                    break;
+                case "tests":
+                    url = provider.getTestsURL(run);
+                    break;
+                default:
+                    url = provider.getRunURL(run);
+                    break;
+            }
         } else {
             url = provider.getRunURL(run);
         }

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/RunDisplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/RunDisplayAction.java
@@ -26,6 +26,8 @@ public class RunDisplayAction extends AbstractDisplayAction {
         String url;
         if ("changes".equals(page)) {
             url = provider.getChangesURL(run);
+        } else if ("artifacts".equals(page)) {
+            url = provider.getArtifactsURL(run);
         } else {
             url = provider.getRunURL(run);
         }

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProviderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProviderTest.java
@@ -33,15 +33,18 @@ public class DisplayURLProviderTest {
         assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect", DisplayURLProvider.get().getRunURL(run));
         assertEquals(root + "job/my%20folder/job/my%20job/display/redirect",
                 DisplayURLProvider.get().getJobURL(project));
-        assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=changes",
-                DisplayURLProvider.get().getChangesURL(run));
         assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=artifacts",
                 DisplayURLProvider.get().getArtifactsURL(run));
+        assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=changes",
+                DisplayURLProvider.get().getChangesURL(run));
+        assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=tests",
+                DisplayURLProvider.get().getTestsURL(run));
 
         EnvVars environment = run.getEnvironment();
         assertEquals(DisplayURLProvider.get().getRunURL(run), environment.get("RUN_DISPLAY_URL"));
-        assertEquals(DisplayURLProvider.get().getChangesURL(run), environment.get("RUN_CHANGES_DISPLAY_URL"));
         assertEquals(DisplayURLProvider.get().getArtifactsURL(run), environment.get("RUN_ARTIFACTS_DISPLAY_URL"));
+        assertEquals(DisplayURLProvider.get().getChangesURL(run), environment.get("RUN_CHANGES_DISPLAY_URL"));
+        assertEquals(DisplayURLProvider.get().getTestsURL(run), environment.get("RUN_TESTS_DISPLAY_URL"));
         assertEquals(DisplayURLProvider.get().getJobURL(project), environment.get("JOB_DISPLAY_URL"));
     }
 
@@ -59,12 +62,15 @@ public class DisplayURLProviderTest {
                 + "&utm_term=my+folder%2Fmy+job%231", DisplayURLProvider.get().getRunURL(run));
         assertEquals(root + "job/my%20folder/job/my%20job/display/redirect?utm_campaign=jenkins&utm_source=Jenkins",
                 DisplayURLProvider.get().getJobURL(project));
-        assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=changes&utm_campaign=jenkins"
-                        + "&utm_source=Jenkins&utm_term=my+folder%2Fmy+job%231",
-                DisplayURLProvider.get().getChangesURL(run));
         assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=artifacts&utm_campaign=jenkins"
                         + "&utm_source=Jenkins&utm_term=my+folder%2Fmy+job%231",
                 DisplayURLProvider.get().getArtifactsURL(run));
+        assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=changes&utm_campaign=jenkins"
+                        + "&utm_source=Jenkins&utm_term=my+folder%2Fmy+job%231",
+                DisplayURLProvider.get().getChangesURL(run));
+        assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=tests&utm_campaign=jenkins"
+                        + "&utm_source=Jenkins&utm_term=my+folder%2Fmy+job%231",
+                DisplayURLProvider.get().getTestsURL(run));
         DisplayURLContext ctx = DisplayURLContext.open();
         try {
             ctx.plugin(Jenkins.getActiveInstance().getPluginManager().getPlugin("display-url-api"));
@@ -76,20 +82,24 @@ public class DisplayURLProviderTest {
                             + "job/my%20folder/job/my%20job/display/redirect?utm_campaign=display-url-api&utm_source"
                             + "=Jenkins",
                     DisplayURLProvider.get().getJobURL(project));
-            assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=changes&utm_campaign=display"
-                            + "-url-api&utm_source=Jenkins&utm_term=my+folder%2Fmy+job%231",
-                    DisplayURLProvider.get().getChangesURL(run));
             assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=artifacts&utm_campaign=display"
                             + "-url-api&utm_source=Jenkins&utm_term=my+folder%2Fmy+job%231",
                     DisplayURLProvider.get().getArtifactsURL(run));
+            assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=changes&utm_campaign=display"
+                            + "-url-api&utm_source=Jenkins&utm_term=my+folder%2Fmy+job%231",
+                    DisplayURLProvider.get().getChangesURL(run));
+            assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=tests&utm_campaign=display"
+                            + "-url-api&utm_source=Jenkins&utm_term=my+folder%2Fmy+job%231",
+                    DisplayURLProvider.get().getTestsURL(run));
         } finally {
             ctx.close();
         }
 
         EnvVars environment = run.getEnvironment();
         assertEquals(DisplayURLProvider.get().getRunURL(run), environment.get("RUN_DISPLAY_URL"));
-        assertEquals(DisplayURLProvider.get().getChangesURL(run), environment.get("RUN_CHANGES_DISPLAY_URL"));
         assertEquals(DisplayURLProvider.get().getArtifactsURL(run), environment.get("RUN_ARTIFACTS_DISPLAY_URL"));
+        assertEquals(DisplayURLProvider.get().getChangesURL(run), environment.get("RUN_CHANGES_DISPLAY_URL"));
+        assertEquals(DisplayURLProvider.get().getTestsURL(run), environment.get("RUN_TESTS_DISPLAY_URL"));
         assertEquals(DisplayURLProvider.get().getJobURL(project), environment.get("JOB_DISPLAY_URL"));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProviderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProviderTest.java
@@ -35,10 +35,13 @@ public class DisplayURLProviderTest {
                 DisplayURLProvider.get().getJobURL(project));
         assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=changes",
                 DisplayURLProvider.get().getChangesURL(run));
+        assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=artifacts",
+                DisplayURLProvider.get().getArtifactsURL(run));
 
         EnvVars environment = run.getEnvironment();
         assertEquals(DisplayURLProvider.get().getRunURL(run), environment.get("RUN_DISPLAY_URL"));
         assertEquals(DisplayURLProvider.get().getChangesURL(run), environment.get("RUN_CHANGES_DISPLAY_URL"));
+        assertEquals(DisplayURLProvider.get().getArtifactsURL(run), environment.get("RUN_ARTIFACTS_DISPLAY_URL"));
         assertEquals(DisplayURLProvider.get().getJobURL(project), environment.get("JOB_DISPLAY_URL"));
     }
 
@@ -59,6 +62,9 @@ public class DisplayURLProviderTest {
         assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=changes&utm_campaign=jenkins"
                         + "&utm_source=Jenkins&utm_term=my+folder%2Fmy+job%231",
                 DisplayURLProvider.get().getChangesURL(run));
+        assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=artifacts&utm_campaign=jenkins"
+                        + "&utm_source=Jenkins&utm_term=my+folder%2Fmy+job%231",
+                DisplayURLProvider.get().getArtifactsURL(run));
         DisplayURLContext ctx = DisplayURLContext.open();
         try {
             ctx.plugin(Jenkins.getActiveInstance().getPluginManager().getPlugin("display-url-api"));
@@ -73,6 +79,9 @@ public class DisplayURLProviderTest {
             assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=changes&utm_campaign=display"
                             + "-url-api&utm_source=Jenkins&utm_term=my+folder%2Fmy+job%231",
                     DisplayURLProvider.get().getChangesURL(run));
+            assertEquals(root + "job/my%20folder/job/my%20job/1/display/redirect?page=artifacts&utm_campaign=display"
+                            + "-url-api&utm_source=Jenkins&utm_term=my+folder%2Fmy+job%231",
+                    DisplayURLProvider.get().getArtifactsURL(run));
         } finally {
             ctx.close();
         }
@@ -80,8 +89,8 @@ public class DisplayURLProviderTest {
         EnvVars environment = run.getEnvironment();
         assertEquals(DisplayURLProvider.get().getRunURL(run), environment.get("RUN_DISPLAY_URL"));
         assertEquals(DisplayURLProvider.get().getChangesURL(run), environment.get("RUN_CHANGES_DISPLAY_URL"));
+        assertEquals(DisplayURLProvider.get().getArtifactsURL(run), environment.get("RUN_ARTIFACTS_DISPLAY_URL"));
         assertEquals(DisplayURLProvider.get().getJobURL(project), environment.get("JOB_DISPLAY_URL"));
-
     }
 
     @TestExtension("decoration")

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/AbstractActionRedirectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/AbstractActionRedirectTest.java
@@ -1,13 +1,20 @@
 package org.jenkinsci.plugins.displayurlapi.actions;
 
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
 import hudson.model.FreeStyleProject;
 import hudson.model.Job;
 import hudson.model.Run;
+import hudson.tasks.ArtifactArchiver;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.jenkinsci.plugins.displayurlapi.JenkinsRuleWithLocalPort;
 import org.junit.Before;
 import org.junit.Rule;
 import org.jvnet.hudson.test.MockFolder;
+import org.jvnet.hudson.test.TestBuilder;
+
+import java.io.IOException;
 
 public abstract class AbstractActionRedirectTest {
     protected Job job;
@@ -21,9 +28,18 @@ public abstract class AbstractActionRedirectTest {
     public void createJobAndRun() throws Exception {
         MockFolder folder = rule.createFolder("my folder");
         FreeStyleProject job = (FreeStyleProject) folder.createProject(rule.jenkins.getDescriptorByType(FreeStyleProject.DescriptorImpl.class), "my job", false);
+        job.getBuildersList().add(new CreateArtifact());
+        job.getPublishersList().add(new ArtifactArchiver("f"));
         this.job = job;
         this.run = job.scheduleBuild2(0).get();
         provider = DisplayURLProvider.get();
+    }
+
+    static class CreateArtifact extends TestBuilder {
+        public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
+            build.getWorkspace().child("f").write("content", "UTF-8");
+            return true;
+        }
     }
 
     protected abstract DisplayURLProvider getRedirectedProvider();

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectClassicTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectClassicTest.java
@@ -1,14 +1,21 @@
 package org.jenkinsci.plugins.displayurlapi.actions;
 
+import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.WebResponse;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import javax.servlet.http.HttpServletResponse;
 
+import java.net.HttpURLConnection;
+import java.net.URL;
+
 import static io.restassured.RestAssured.given;
+import static org.junit.Assert.assertEquals;
 
 public class ActionRedirectClassicTest extends AbstractActionRedirectTest {
 
@@ -20,6 +27,13 @@ public class ActionRedirectClassicTest extends AbstractActionRedirectTest {
             .when().get(provider.getJobURL(job)).then()
             .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
             .header("Location", getRedirectedProvider().getJobURL(job));
+
+        JenkinsRule.WebClient wc = rule.createWebClient()
+                .withRedirectEnabled(true)
+                .withThrowExceptionOnFailingStatusCode(false);
+
+        WebResponse rsp = wc.getPage(new WebRequest(new URL(provider.getJobURL(job)))).getWebResponse();
+        assertEquals(rsp.getContentAsString(), HttpURLConnection.HTTP_OK, rsp.getStatusCode());
     }
 
     @Test
@@ -30,6 +44,13 @@ public class ActionRedirectClassicTest extends AbstractActionRedirectTest {
             .when().get(provider.getRunURL(run)).then()
             .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
             .header("Location", getRedirectedProvider().getRunURL(run));
+
+        JenkinsRule.WebClient wc = rule.createWebClient()
+                .withRedirectEnabled(true)
+                .withThrowExceptionOnFailingStatusCode(false);
+
+        WebResponse rsp = wc.getPage(new WebRequest(new URL(provider.getRunURL(run)))).getWebResponse();
+        assertEquals(rsp.getContentAsString(), HttpURLConnection.HTTP_OK, rsp.getStatusCode());
     }
 
     @Test
@@ -40,6 +61,13 @@ public class ActionRedirectClassicTest extends AbstractActionRedirectTest {
             .when().get(provider.getArtifactsURL(run)).then()
             .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
             .header("Location", getRedirectedProvider().getArtifactsURL(run));
+
+        JenkinsRule.WebClient wc = rule.createWebClient()
+                .withRedirectEnabled(true)
+                .withThrowExceptionOnFailingStatusCode(false);
+
+        WebResponse rsp = wc.getPage(new WebRequest(new URL(provider.getArtifactsURL(run)))).getWebResponse();
+        assertEquals(rsp.getContentAsString(), HttpURLConnection.HTTP_OK, rsp.getStatusCode());
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectClassicTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectClassicTest.java
@@ -33,16 +33,6 @@ public class ActionRedirectClassicTest extends AbstractActionRedirectTest {
     }
 
     @Test
-    public void testRedirectForChangesURL() throws Exception {
-        given()
-            .urlEncodingEnabled(false)
-            .redirects().follow(false)
-            .when().get(provider.getChangesURL(run)).then()
-            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
-            .header("Location", getRedirectedProvider().getChangesURL(run));
-    }
-
-    @Test
     public void testRedirectForArtifactsURL() throws Exception {
         given()
             .urlEncodingEnabled(false)
@@ -50,6 +40,26 @@ public class ActionRedirectClassicTest extends AbstractActionRedirectTest {
             .when().get(provider.getArtifactsURL(run)).then()
             .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
             .header("Location", getRedirectedProvider().getArtifactsURL(run));
+    }
+
+    @Test
+    public void testRedirectForChangesURL() throws Exception {
+        given()
+                .urlEncodingEnabled(false)
+                .redirects().follow(false)
+                .when().get(provider.getChangesURL(run)).then()
+                .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+                .header("Location", getRedirectedProvider().getChangesURL(run));
+    }
+
+    @Test
+    public void testRedirectForTestsURL() throws Exception {
+        given()
+                .urlEncodingEnabled(false)
+                .redirects().follow(false)
+                .when().get(provider.getTestsURL(run)).then()
+                .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+                .header("Location", getRedirectedProvider().getTestsURL(run));
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectClassicTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectClassicTest.java
@@ -42,6 +42,16 @@ public class ActionRedirectClassicTest extends AbstractActionRedirectTest {
             .header("Location", getRedirectedProvider().getChangesURL(run));
     }
 
+    @Test
+    public void testRedirectForArtifactsURL() throws Exception {
+        given()
+            .urlEncodingEnabled(false)
+            .redirects().follow(false)
+            .when().get(provider.getArtifactsURL(run)).then()
+            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+            .header("Location", getRedirectedProvider().getArtifactsURL(run));
+    }
+
     @Override
     protected DisplayURLProvider getRedirectedProvider() {
         return Iterables.find(DisplayURLProvider.all(), Predicates.instanceOf(ClassicDisplayURLProvider.class));

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectEligibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectEligibilityTest.java
@@ -119,6 +119,11 @@ public class ActionRedirectEligibilityTest extends AbstractActionRedirectTest {
         }
 
         @Override
+        public String getArtifactsURL(Run<?, ?> run) {
+            return ELIGIBLE_IN_URL;
+        }
+
+        @Override
         public String getJobURL(Job<?, ?> project) {
             return ELIGIBLE_IN_URL;
         }

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectEligibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectEligibilityTest.java
@@ -119,6 +119,11 @@ public class ActionRedirectEligibilityTest extends AbstractActionRedirectTest {
         }
 
         @Override
+        public String getTestsURL(Run<?, ?> run) {
+            return ELIGIBLE_IN_URL;
+        }
+
+        @Override
         public String getArtifactsURL(Run<?, ?> run) {
             return ELIGIBLE_IN_URL;
         }

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
@@ -68,8 +68,8 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
     }
 
     @Test
-    public void testRedirectForTestsURLWithCustomsTestsFolder() throws Exception {
-        System.setProperty("jenkins.displayurl.tests.folder", "folder");
+    public void testRedirectForTestsURLWithClassicTestsFolder() throws Exception {
+        System.setProperty("jenkins.classic.displayurl.tests.folder", "folder");
         given()
                 .urlEncodingEnabled(false)
                 .redirects().follow(false)

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
@@ -17,6 +17,7 @@ import static io.restassured.RestAssured.given;
 import static org.junit.Assert.assertEquals;
 
 public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
+
     @Test
     public void testRedirectForJobURL() throws Exception {
         given()
@@ -40,11 +41,11 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
     @Test
     public void testRedirectForArtifactsURL() throws Exception {
         given()
-                .urlEncodingEnabled(false)
-                .redirects().follow(false)
-                .when().get(provider.getArtifactsURL(run)).then()
-                .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
-                .header("Location", getRedirectedProvider().getArtifactsURL(run));
+            .urlEncodingEnabled(false)
+            .redirects().follow(false)
+            .when().get(provider.getArtifactsURL(run)).then()
+            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+            .header("Location", getRedirectedProvider().getArtifactsURL(run));
     }
 
     @Test
@@ -60,32 +61,32 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
     @Test
     public void testRedirectForTestsURL() throws Exception {
         given()
-                .urlEncodingEnabled(false)
-                .redirects().follow(false)
-                .when().get(provider.getTestsURL(run)).then()
-                .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
-                .header("Location", getRedirectedProvider().getTestsURL(run));
+            .urlEncodingEnabled(false)
+            .redirects().follow(false)
+            .when().get(provider.getTestsURL(run)).then()
+            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+            .header("Location", getRedirectedProvider().getTestsURL(run));
     }
 
     @Test
     public void testRedirectForTestsURLWithClassicTestsFolder() throws Exception {
         System.setProperty("jenkins.classic.displayurl.tests.folder", "folder");
         given()
-                .urlEncodingEnabled(false)
-                .redirects().follow(false)
-                .when().get(provider.getTestsURL(run)).then()
-                .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
-                .header("Location", getRedirectedProvider().getTestsURL(run));
+            .urlEncodingEnabled(false)
+            .redirects().follow(false)
+            .when().get(provider.getTestsURL(run)).then()
+            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+            .header("Location", getRedirectedProvider().getTestsURL(run));
     }
 
     @Test
     public void testRedirectForYetAnotherProviderParameter() throws Exception {
         given()
-                .urlEncodingEnabled(false)
-                .redirects().follow(false)
-                .when().get(provider.getChangesURL(run) + "&provider=YetAnotherDisplayURLProvider").then()
-                .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
-                .header("Location", getYetAnotherRedirectedProvider().getChangesURL(run));
+            .urlEncodingEnabled(false)
+            .redirects().follow(false)
+            .when().get(provider.getChangesURL(run) + "&provider=YetAnotherDisplayURLProvider").then()
+            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+            .header("Location", getYetAnotherRedirectedProvider().getChangesURL(run));
     }
 
     @Test
@@ -101,12 +102,9 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
 
     @Test
     public void testUrlsTestsFolder() throws Exception {
-        System.setProperty("jenkins.displayurl.tests.folder", "folder");
+        System.setProperty("jenkins.classic.displayurl.tests.folder", "folder");
         String root = DisplayURLProvider.get().getRoot();
         assertEquals(root + "job/my%20folder/job/my%20job/1/folderanother", getRedirectedProvider().getTestsURL(run));
-
-        System.setProperty("jenkins.displayurl.provider", ClassicDisplayURLProvider.class.getName());
-        Assert.assertThat(DisplayURLProvider.getDefault(), Matchers.instanceOf(ClassicDisplayURLProvider.class));
     }
 
 

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
@@ -45,6 +45,16 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
     }
 
     @Test
+    public void testRedirectForArtifactsURL() throws Exception {
+        given()
+            .urlEncodingEnabled(false)
+            .redirects().follow(false)
+            .when().get(provider.getArtifactsURL(run)).then()
+            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+            .header("Location", getRedirectedProvider().getArtifactsURL(run));
+    }
+
+    @Test
     public void testRedirectForYetAnotherProviderParameter() throws Exception {
         given()
                 .urlEncodingEnabled(false)
@@ -61,6 +71,7 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
         assertEquals(root + "job/my%20folder/job/my%20job/1/another", getRedirectedProvider().getRunURL(run));
         assertEquals(root + "job/my%20folder/job/my%20job/another", getRedirectedProvider().getJobURL(job));
         assertEquals(root + "job/my%20folder/job/my%20job/changesanother", getRedirectedProvider().getChangesURL(run));
+        assertEquals(root + "job/my%20folder/job/my%20job/1/artifactanother", getRedirectedProvider().getArtifactsURL(run));
     }
 
 
@@ -89,6 +100,11 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
         }
 
         @Override
+        public String getArtifactsURL(Run<?, ?> run) {
+            return DisplayURLProvider.getDefault().getArtifactsURL(run) + EXTRA_CONTENT_IN_URL;
+        }
+
+        @Override
         public String getJobURL(Job<?, ?> project) {
             return DisplayURLProvider.getDefault().getJobURL(project) + EXTRA_CONTENT_IN_URL;
         }
@@ -107,6 +123,11 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
         @Override
         public String getChangesURL(Run<?, ?> run) {
             return DisplayURLProvider.getDefault().getChangesURL(run) + EXTRA_CONTENT_IN_URL;
+        }
+
+        @Override
+        public String getArtifactsURL(Run<?, ?> run) {
+            return DisplayURLProvider.getDefault().getArtifactsURL(run) + EXTRA_CONTENT_IN_URL;
         }
 
         @Override

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
@@ -69,17 +69,6 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
     }
 
     @Test
-    public void testRedirectForTestsURLWithClassicTestsFolder() throws Exception {
-        System.setProperty("jenkins.classic.displayurl.tests.folder", "folder");
-        given()
-            .urlEncodingEnabled(false)
-            .redirects().follow(false)
-            .when().get(provider.getTestsURL(run)).then()
-            .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
-            .header("Location", getRedirectedProvider().getTestsURL(run));
-    }
-
-    @Test
     public void testRedirectForYetAnotherProviderParameter() throws Exception {
         given()
             .urlEncodingEnabled(false)
@@ -98,13 +87,6 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
         assertEquals(root + "job/my%20folder/job/my%20job/1/artifactanother", getRedirectedProvider().getArtifactsURL(run));
         assertEquals(root + "job/my%20folder/job/my%20job/changesanother", getRedirectedProvider().getChangesURL(run));
         assertEquals(root + "job/my%20folder/job/my%20job/1/testReportanother", getRedirectedProvider().getTestsURL(run));
-    }
-
-    @Test
-    public void testUrlsTestsFolder() throws Exception {
-        System.setProperty("jenkins.classic.displayurl.tests.folder", "folder");
-        String root = DisplayURLProvider.get().getRoot();
-        assertEquals(root + "job/my%20folder/job/my%20job/1/folderanother", getRedirectedProvider().getTestsURL(run));
     }
 
 

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
@@ -97,7 +97,7 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
         assertEquals(root + "job/my%20folder/job/my%20job/another", getRedirectedProvider().getJobURL(job));
         assertEquals(root + "job/my%20folder/job/my%20job/1/artifactanother", getRedirectedProvider().getArtifactsURL(run));
         assertEquals(root + "job/my%20folder/job/my%20job/changesanother", getRedirectedProvider().getChangesURL(run));
-        assertEquals(root + "job/my%20folder/job/my%20job/1/another", getRedirectedProvider().getTestsURL(run));
+        assertEquals(root + "job/my%20folder/job/my%20job/1/testReportanother", getRedirectedProvider().getTestsURL(run));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/displayurlapi/actions/ActionRedirectExtendedTest.java
@@ -45,6 +45,16 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
     }
 
     @Test
+    public void testRedirectForTestsURL() throws Exception {
+        given()
+                .urlEncodingEnabled(false)
+                .redirects().follow(false)
+                .when().get(provider.getTestsURL(run)).then()
+                .statusCode(HttpServletResponse.SC_MOVED_TEMPORARILY)
+                .header("Location", getRedirectedProvider().getTestsURL(run));
+    }
+
+    @Test
     public void testRedirectForArtifactsURL() throws Exception {
         given()
             .urlEncodingEnabled(false)
@@ -100,6 +110,11 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
         }
 
         @Override
+        public String getTestsURL(Run<?, ?> run) {
+            return DisplayURLProvider.getDefault().getTestsURL(run) + EXTRA_CONTENT_IN_URL;
+        }
+
+        @Override
         public String getArtifactsURL(Run<?, ?> run) {
             return DisplayURLProvider.getDefault().getArtifactsURL(run) + EXTRA_CONTENT_IN_URL;
         }
@@ -123,6 +138,11 @@ public class ActionRedirectExtendedTest extends AbstractActionRedirectTest {
         @Override
         public String getChangesURL(Run<?, ?> run) {
             return DisplayURLProvider.getDefault().getChangesURL(run) + EXTRA_CONTENT_IN_URL;
+        }
+
+        @Override
+        public String getTestsURL(Run<?, ?> run) {
+            return DisplayURLProvider.getDefault().getTestsURL(run) + EXTRA_CONTENT_IN_URL;
         }
 
         @Override


### PR DESCRIPTION
[JENKINS-53179](https://issues.jenkins-ci.org/browse/JENKINS-53179)

Enable URLs for a page that displays tests and artifacts for a Run as env variables and also support the redirect

## Highlights
- `<BUILD_URL>redirect?page=artifacts` is enabled and `RUN_ARTIFACTS_DISPLAY_URL` env variable points out to that qualified URL.
- `<BUILD_URL>redirect?page=tests` is enabled and `RUN_TESTS_DISPLAY_URL` env variable points out to that qualified URL.
- `RUN_TESTS_DISPLAY_URL` redirects to the `testReport` url of the current run.
- `RUN_ARTIFACTS_DISPLAY_URL` redirects to the `artifact` url of the current run.

## Clarification
- Variable names are plural rather than singular as it seems that's the default new naming within `BO`. For instance: artifacts, tests, changes, and pipelines are the tab names in BO.

## Test Cases
- Default URLs
![image](https://user-images.githubusercontent.com/2871786/59006761-8f3aca00-881b-11e9-9f09-dc71b604a738.png)

@jenkinsci/code-reviewers 