### PR TITLE
Fix styling of provider selector

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty.java
@@ -3,9 +3,12 @@ package org.jenkinsci.plugins.displayurlapi.user;
 import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
+import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
+
 import java.util.stream.Collectors;
+
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -28,6 +31,19 @@ public class PreferredProviderUserProperty extends UserProperty {
         final DisplayURLProvider provider = getConfiguredProvider();
         return provider == null ? ProviderOption.DEFAULT_OPTION
             : new ProviderOption(provider.getClass().getName(), provider.getDisplayName());
+    }
+
+    public static PreferredProviderUserProperty forCurrentUser() {
+        final User current = User.current();
+        if (current == null) {
+            return (PreferredProviderUserProperty) DESCRIPTOR.newInstance((User) null);
+        }
+
+        PreferredProviderUserProperty property = current.getProperty(PreferredProviderUserProperty.class);
+        if (property == null) {
+            return (PreferredProviderUserProperty) DESCRIPTOR.newInstance(current);
+        }
+        return property;
     }
 
     public DisplayURLProvider getConfiguredProvider() {

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserPropertyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserPropertyDescriptor.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
+import hudson.util.ListBoxModel;
 import org.jenkinsci.plugins.displayurlapi.Messages;
 import org.jenkinsci.plugins.displayurlapi.user.PreferredProviderUserProperty.ProviderOption;
 
@@ -16,6 +17,20 @@ public class PreferredProviderUserPropertyDescriptor extends UserPropertyDescrip
     @Override
     public UserProperty newInstance(User user) {
         return new PreferredProviderUserProperty(ProviderOption.DEFAULT_OPTION.getId());
+    }
+
+    public ListBoxModel doFillProviderIdItems() {
+        ListBoxModel items = new ListBoxModel();
+        PreferredProviderUserProperty property = PreferredProviderUserProperty.forCurrentUser();
+        for (ProviderOption providerOption : property.getAll()) {
+            ListBoxModel.Option option = new ListBoxModel.Option(
+                    providerOption.getName(),
+                    providerOption.getId(),
+                    property.isSelected(providerOption.getId())
+            );
+            items.add(option);
+        }
+        return items;
     }
 
     @Override

--- a/src/main/resources/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty/config.jelly
@@ -2,8 +2,8 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:block>
-    <f:entry name="providerId" field="providerId">
-        <select name="providerId">
+    <f:entry field="providerId">
+        <select class="setting-input dropdownList" name="providerId">
             <j:forEach var="provider" items="${instance.all}">
                 <j:choose>
                    <j:when test="${instance.isSelected(provider.getId())}">

--- a/src/main/resources/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/displayurlapi/user/PreferredProviderUserProperty/config.jelly
@@ -3,18 +3,7 @@
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:block>
     <f:entry field="providerId">
-        <select class="setting-input dropdownList" name="providerId">
-            <j:forEach var="provider" items="${instance.all}">
-                <j:choose>
-                   <j:when test="${instance.isSelected(provider.getId())}">
-                     <option value="${provider.getId()}" selected="true">${provider.getName()}</option>
-                   </j:when>
-                   <j:otherwise>
-                     <option value="${provider.getId()}">${provider.getName()}</option>
-                   </j:otherwise>
-                </j:choose>
-            </j:forEach>
-        </select>
+        <f:select/>
     </f:entry>
   </f:block>
 </j:jelly>


### PR DESCRIPTION
In https://github.com/jenkinsci/display-url-api-plugin/commit/7dd7e0467014d3e73676df26f9378c05df805c5e I just did the minimal change to fix the styling, but I think it's better that we use the correct jelly / stapler API and build it properly.

Before:
![image](https://user-images.githubusercontent.com/21194782/119100546-f99ca300-ba0f-11eb-8a0b-dcb6171d0942.png)


After:
![image](https://user-images.githubusercontent.com/21194782/119100476-e689d300-ba0f-11eb-8eab-2622ac8795db.png)

cc @olamy @dwnusbaum @bitwiseman @kshultzCB @rsandell 
