### PR TITLE
Update plugin parent POM and plugin BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.18</version>
+    <version>4.37</version>
   </parent>
 
   <artifactId>display-url-api</artifactId>
@@ -15,7 +15,7 @@
   <properties>
     <revision>2.3.6</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.176.4</jenkins.version>
+    <jenkins.version>2.332.1</jenkins.version>
     <java.level>8</java.level>
     <hamcrest.version>2.2</hamcrest.version>
   </properties>
@@ -63,8 +63,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.176.x</artifactId>
-        <version>16</version>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1198.v387c834fca_1a_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
Updates the plugin parent POM to the latest version and adjusts the minimum Jenkins version to the latest LTS along with updating the plugin BOM accordingly. This is necessary in order to be able to test this plugin on Java 17, as I am trying to do in https://github.com/jenkinsci/bom/pull/935. With these changes I can run `mvn clean verify -Djenkins-test-harness.version=1721.v385389722736 '-DargLine=--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED'` successfully on Java 17. CC @olamy 