### PR TITLE
Incrementalize plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,13 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.332.1</jenkins.version>
     <java.level>8</java.level>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <hamcrest.version>2.2</hamcrest.version>
   </properties>
 
   <name>Display URL API</name>
   <description>Provides the DisplayURLProvider extension point to provide alternate URLs for use in notifications</description>
-  <url>https://github.com/jenkinsci/display-url-api-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <licenses>
     <license>
@@ -40,10 +41,10 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
   <repositories>


### PR DESCRIPTION
The incremental deployment of

https://ci.jenkins.io/job/Plugins/job/display-url-api-plugin/job/master/110/consoleFull

failed with

```
18:20:28  HttpMethod: POST
18:20:28  URL: https://incrementals.jenkins.io/
18:20:28  Content-Type: application/json
18:20:28  Authorization: *****
18:20:28  Sending request to url: https://incrementals.jenkins.io/
18:20:29  Response Code: HTTP/1.1 400 Bad Request
18:20:29  Response: 
18:20:29  Invalid archive retrieved from Jenkins, perhaps the plugin is not properly incrementalized?
18:20:29  Error: ZIP error: Error: Missing <tag> section in <scm> of org/jenkins-ci/plugins/display-url-api/2.3.6-rc156.f6b_97fd4b_c37/display-url-api-2.3.6-rc156.f6b_97fd4b_c37.pom from https://ci.jenkins.io/job/Plugins/job/display-url-api-plugin/job/master/110/artifact/**/*f6b*97fd4b*c37*/*f6b*97fd4b*c37*/*zip*/archive.zip
18:20:29  Success: Status code 400 is in the accepted range: 100:599
```

so I cannot use it in jenkinsci/bom#935. This PR corrects the problem by applying the plugin POM recommendations from `jenkinsci/archetypes`.