### PR TITLE
[JENKINS-73014] adapt plugin to allow config by users with overall/manage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.73</version>
+    <version>4.81</version>
     <relativePath />
   </parent>
 
@@ -18,6 +18,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.361.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <useBeta>true</useBeta> <!-- Jenkins.MANAGE -->
   </properties>
 
   <name>Display URL API</name>

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/DefaultDisplayURLProviderGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/DefaultDisplayURLProviderGlobalConfiguration.java
@@ -25,12 +25,15 @@
 package org.jenkinsci.plugins.displayurlapi;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.Util;
+import hudson.security.Permission;
 import hudson.util.ListBoxModel;
 import java.util.Objects;
 import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.displayurlapi.user.PreferredProviderUserProperty;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -49,6 +52,11 @@ public class DefaultDisplayURLProviderGlobalConfiguration extends GlobalConfigur
         return providerId;
     }
 
+    @NonNull
+    @Override
+    public Permission getRequiredGlobalConfigPagePermission() {
+        return Jenkins.MANAGE;
+    }
     @DataBoundSetter
     public void setProviderId(@CheckForNull String providerId) {
         providerId = Util.fixEmptyAndTrim(providerId);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Allows for users with `Overall/Manage` permission to configure this plugin under `Manage Jenkins --> System`.  If support for `Overall/Manage` permission is not enabled then only users with `Administer` will be able to modify the configuration.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
