### PR TITLE
Replace `StringUtils` with Java Platform functionality

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/DisplayURLProvider.java
@@ -9,11 +9,8 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.User;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.displayurlapi.actions.AbstractDisplayAction;
 import org.jenkinsci.plugins.displayurlapi.user.PreferredProviderUserProperty;
-
-import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
 /**
  * Generates URLs for well known UI locations for use in notifications (e.g. mailer, HipChat, Slack,
@@ -183,7 +180,7 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
 
     private static String findClass() {
         String clazz = System.getenv(JENKINS_DISPLAYURL_PROVIDER_ENV);
-        if (StringUtils.isEmpty(clazz)) {
+        if (clazz == null || clazz.isEmpty()) {
             clazz = System.getProperty(JENKINS_DISPLAYURL_PROVIDER_PROP);
         }
         return clazz;
@@ -214,7 +211,7 @@ public abstract class DisplayURLProvider implements ExtensionPoint {
             return globalGuiProvider;
         }
         String globalProviderClass = findClass();
-        if (isNotEmpty(globalProviderClass)) {
+        if (globalProviderClass != null && !globalProviderClass.isEmpty()) {
             return ExtensionList.lookup(DisplayURLProvider.class).getDynamic(globalProviderClass);
         }
         ExtensionList<DisplayURLProvider> all = DisplayURLProvider.all();

--- a/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/AbstractDisplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/displayurlapi/actions/AbstractDisplayAction.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.displayurlapi.actions;
 import hudson.ExtensionList;
 import hudson.model.Action;
 import java.util.Objects;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
@@ -40,7 +39,7 @@ public abstract class AbstractDisplayAction implements Action {
 
     DisplayURLProvider lookupProvider(StaplerRequest2 req) {
         final String providerName = req.getParameter("provider");
-        if (StringUtils.isNotEmpty(providerName)) {
+        if (providerName != null && !providerName.isEmpty()) {
             ExtensionList<DisplayURLProvider> providers = DisplayURLProvider.all();
             DisplayURLProvider provider = providers.stream()
                 .filter(Objects::nonNull)


### PR DESCRIPTION
No need to depend on a third-party library for this functionality.